### PR TITLE
(Re)download missing local files

### DIFF
--- a/SPSync.Core/SyncManager.cs
+++ b/SPSync.Core/SyncManager.cs
@@ -700,7 +700,11 @@ namespace SPSync.Core
                             OnItemProgress((int)(((double)countFiles / (double)countAllFiles) * 100), ItemType.File, ProgressStatus.Warning, "File locked. Trying again later...", ex);
                         }
                     }
-                    else if (item.Status == ItemStatus.UpdatedRemote && syncToLocal)
+                    else if (
+                        (item.Status == ItemStatus.UpdatedRemote && syncToLocal)
+                        // one-way sync (RemoteToLocal), and file is missing: download it
+                        || (item.Status == ItemStatus.DeletedLocal && syncToLocal && !syncToRemote)
+                        )
                     {
                         OnItemProgress((int)(((double)countFiles / (double)countAllFiles) * 100), ItemType.File, ProgressStatus.Running, string.Format("Updating local file {0}...", item.Name));
 


### PR DESCRIPTION
Sometimes a file isn't downloaded due to reasons beyond the program's
control.
This change enables those missing files to be retrieved, if it is a
one-way, remote-to-local sync.